### PR TITLE
Require TinyMCE when ExpressBlog is installed

### DIFF
--- a/app/views/layouts/express_admin/admin.html.haml
+++ b/app/views/layouts/express_admin/admin.html.haml
@@ -20,4 +20,12 @@
         = yield
     - if Kernel.const_defined?('AppExpress::Engine')
       = javascript_include_tag 'message-bus'
+    - if Kernel.const_defined?('ExpressBlog::Engine')
+      = javascript_include_tag 'tinymce-jquery'
+      :javascript
+        $(function() {
+          tinyMCE.init({
+            selector: 'textarea.tinymce'
+          });
+        });
     = yield(:page_javascript)

--- a/lib/express_admin/engine.rb
+++ b/lib/express_admin/engine.rb
@@ -15,6 +15,9 @@ module ExpressAdmin
       if Kernel.const_defined?('AppExpress::Engine')
         Rails.application.config.assets.precompile += %w( message-bus.js )
       end
+      if Kernel.const_defined?('ExpressBlog::Engine')
+        Rails.application.config.assets.precompile += %w( tinymce-jquery.js )
+      end
     end
 
     config.autoload_paths += Dir[ExpressAdmin::Engine.root.join('app', 'jobs')]


### PR DESCRIPTION
This pull request compiles TinyMCE when ExpressBlog is installed. For context here is [the pull request in question](https://github.com/aelogica/express_blog/pull/4).
