### PR TITLE
Prepare for release

### DIFF
--- a/lib/express_admin/engine.rb
+++ b/lib/express_admin/engine.rb
@@ -7,6 +7,7 @@ require 'select2-rails'
 require 'ostruct'
 require 'underscore-rails'
 require 'underscore-string-rails'
+require 'foundation-rails'
 
 def gem_path(gem)
   Gem::Specification.find_by_name(gem).gem_dir

--- a/lib/generators/express_admin/install/install_generator.rb
+++ b/lib/generators/express_admin/install/install_generator.rb
@@ -1,22 +1,9 @@
 class ExpressAdmin::InstallGenerator < Rails::Generators::Base
   source_root File.expand_path('../templates', __FILE__)
 
-  desc "mount express_admin engine; migrate database"
+  desc "mount express_admin engine"
   def install
-    route_code = %Q{
-  mount ExpressAdmin::Engine, at: ExpressAdmin::Engine.config.admin_mount_point\n}
-    inject_into_file "#{Rails.root}/config/routes.rb", route_code, after: "Rails.application.routes.draw do\n"
-
-    rails_admin_gem_line = <<-EXPRESS_RAILS_ADMIN
-  gem 'rails_admin', github: 'aelogica/express_rails_admin'
-EXPRESS_RAILS_ADMIN
-    inject_into_file "Gemfile", rails_admin_gem_line, after: "group :app_express do\n"
-
-
-    Bundler.clean_system("bundle install")
-    Bundler.clean_system("rails generate rails_admin:install admin/manage")
-    Bundler.clean_system("rake express_admin:install:migrations")
-    Bundler.clean_system("rake db:migrate")
+    route "mount ExpressAdmin::Engine, at: ExpressAdmin::Engine.config.admin_mount_point"
   end
 
 end

--- a/template.rb
+++ b/template.rb
@@ -1,49 +1,8 @@
-require 'bundler'
-Bundler.setup
-
-git :init
-git add: "."
-git commit: "-a -m 'Initial commit'"
-
-ruby_version = ask("What ruby version do you want to use ?")
-ruby_gemset = ask("What gemset do you want to use ?")
-
-file ".ruby-version", ruby_version
-file ".ruby-gemset", ruby_gemset
-
-git add: ".ruby-version"
-git add: ".ruby-gemset"
-git commit: "-a -m 'Ruby version and gemset'"
-
-gem 'express_templates'
-gem 'modernizr-rails'
-gem 'therubyracer'
-gem 'foundation-rails'
+gem 'sqlite3'
 gem 'devise'
+gem 'unicorn'
+gem 'resque'
 
-gem_group :app_express do
-  gem 'express_admin', github: 'aelogica/express_admin'
+gem_group :production do
+  gem 'rails_12factor'
 end
-
-app_express_gem_group = <<-GEM_GROUP
-    Bundler.require(:app_express, Rails.env) if defined?(Bundler)
-GEM_GROUP
-inject_into_file 'config/application.rb', app_express_gem_group, after: "class Application < Rails::Application\n"
-
-Bundler.clean_system "bundle install"
-
-git add: "Gemfile"
-git add: "Gemfile.lock"
-git commit: "-m 'Added gems'"
-
-Bundler.clean_system "rails generate foundation:install --force"
-git add: "."
-git commit: "-a -m 'Installed Foundation'"
-
-Bundler.clean_system "rails generate devise:install && rails generate devise User --force && rake db:migrate"
-git add: "."
-git commit: "-a -m 'Installed Devise'"
-
-Bundler.clean_system "rails generate express_admin:install --force"
-git add: "."
-git commit: "-a -m 'Installed ExpressAdmin'"


### PR DESCRIPTION
This assumes the following:
- Devise is installed on the host app
- Devise has a generated `User` model

`express_rails_admin` was removed because it's not part of the module's scope.