### PR TITLE
Limit jquery form validation to smart forms only

### DIFF
--- a/app/assets/javascripts/express_admin/form_validation.js.coffee
+++ b/app/assets/javascripts/express_admin/form_validation.js.coffee
@@ -1,5 +1,5 @@
 $ ->
-  $('form').validate
+  $('form.smart-form').validate
     debug: true
     errorElement: 'span'
 


### PR DESCRIPTION
- ExpressSurvey forms aren't responding to jquery validation