### PR TITLE
Fix JS and style of flash message

### DIFF
--- a/app/assets/stylesheets/express_admin/shared/_alerts.sass
+++ b/app/assets/stylesheets/express_admin/shared/_alerts.sass
@@ -74,3 +74,7 @@
 
 .dot
   color: transparent
+
+@media only screen and (min-width: 320px) and (max-width: 480px)
+  .flash-messages
+    width: 300px

--- a/app/components/express_admin/flash_messages.rb
+++ b/app/components/express_admin/flash_messages.rb
@@ -12,10 +12,12 @@ module ExpressAdmin
       content_for(:page_javascript) {
         script {
           %Q(
-            $(function() {
-              $('a.close').on('click', function(e){
-                e.preventDefault()
-                $(this).parents('.flash-messages').parent().remove()
+            window.addEventListener("load", function() {
+              $(function() {
+                $('a.close').on('click', function(e){
+                  e.preventDefault()
+                  $(this).parents('.flash-messages').remove()
+                })
               })
             });
           ).html_safe


### PR DESCRIPTION
Responsive flash message: 
![screen shot 2015-09-24 at 12 47 02](https://cloud.githubusercontent.com/assets/7299974/10065562/82b00514-62ba-11e5-82a3-bcddaa08b283.png)


Original JS code also removes create-account form when closing the flash message. Edited said code so that only the flash message will be closed when 'x' button is clicked.